### PR TITLE
Little bit of cleanup

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -37,7 +37,7 @@ jobs:
       # until https://github.com/google/osv-scanner/pull/432 is merged
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version-file: go.mod
 
       - name: Install 
         run: |

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -2,14 +2,17 @@ name: "Scan"
 
 on:
   push:
-    branches: [main]
+    branches:
+      - "main"
   pull_request:
-    branches: [main]
+    branches:
+      - "main"
   schedule:
     - cron: "0 9 * * *"
 
 jobs:
   codeql:
+    name: "CodeQL"
     runs-on: ubuntu-latest
 
     permissions:
@@ -17,22 +20,24 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize 
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
 
       - name: Build
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       - name: Analyze 
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
+
   osv:
+    name: "OSV"
     runs-on: ubuntu-latest
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # until https://github.com/google/osv-scanner/pull/432 is merged
       - uses: actions/setup-go@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   test:
+    name: "Go"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -19,7 +20,17 @@ jobs:
         with:
           go-version-file: go.mod
       - run: go test ./...
+
+  debug:
+    name: "Debug"
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Event name: ${{ github.event_name }}"
+          echo "Changed files: ${{ toJson(github.event.pull_request.changed_files) }}"
+  
   fuzz:
+    name: "Fuzz"
     if: github.event_name == 'schedule' || (github.event_name == 'pull_request' && contains(github.event.pull_request.changed_files, 'pkg/jwt/'))
     timeout-minutes: 10
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           go-version-file: go.mod
       - run: go test ./...
   fuzz:
-    if: github.event_name == 'schedule' || (github.event_name == 'pull_request' && contains(github.event.pull_request.changed_files, 'jwt/'))
+    if: github.event_name == 'schedule' || (github.event_name == 'pull_request' && contains(github.event.pull_request.changed_files, 'pkg/jwt/'))
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
   - cron: "0 9 * * *"
 
 jobs:
-  test:
+  go:
     name: "Go"
     runs-on: ubuntu-latest
     steps:
@@ -20,50 +20,3 @@ jobs:
         with:
           go-version-file: go.mod
       - run: go test ./...
-
-  debug:
-    name: "Debug"
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          echo "Event name: ${{ github.event_name }}"
-          echo "Changed files: ${{ toJson(github.event.pull_request.changed_files) }}"
-  
-  fuzz:
-    name: "Fuzz"
-    if: github.event_name == 'schedule' || (github.event_name == 'pull_request' && contains(github.event.pull_request.changed_files, 'pkg/jwt/'))
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
-        with:
-          go-version-file: go.mod
-      - name: Test
-        run: go test ./pkg/jwt -fuzztime=4m30s -fuzz .
-      - name: Report
-        if: failure() && github.event_name == 'schedule'
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # dump crashing output for debugging
-          find pkg/jwt/testdata/fuzz ! -type d -print -exec cat {} \;
-
-          # collect crashers for issue comment
-          CRASHERS=$(find pkg/jwt/testdata/fuzz ! -type d -exec cat {} \;)
-
-          # wrap in markdown code block
-          CRASHERS="\`\`\`\n$CRASHERS\n\`\`\`"
-          
-          # check if an issue already exists, add comment if it does
-          gh issue list --state open | grep -q "Fuzzing Failure $GITHUB_REF"
-          if [ $? -eq 0 ]; then
-            # get the issue number
-            ISSUE_NUMBER=$(gh issue list --state open | grep "Fuzzing Failure $GITHUB_REF" | awk '{print $1}')
-            # add a comment
-            gh issue comment $ISSUE_NUMBER --body "Fuzzing failed on $GITHUB_REF, see $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID for details.\n$CRASHERS"
-            exit 0
-          fi
-
-          # create an issue
-          gh issue create --title "Fuzzing Failure $GITHUB_REF" --body "Fuzzing failed on $GITHUB_REF, see $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID for details.\n$CRASHERS"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version-file: go.mod
       - run: go test ./...
   fuzz:
     if: github.event_name == 'schedule' || (github.event_name == 'pull_request' && contains(github.event.pull_request.changed_files, 'jwt/'))
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version-file: go.mod
       - name: Test
         run: go test ./pkg/jwt -fuzztime=4m30s -fuzz .
       - name: Report

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,8 @@
 module github.com/picatz/jose
 
-go 1.19
+go 1.23.0
 
-require (
-	github.com/stretchr/testify v1.8.4
-	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
-)
+require github.com/stretchr/testify v1.9.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/pkg/header/header.go
+++ b/pkg/header/header.go
@@ -3,23 +3,45 @@ package header
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/picatz/jose/pkg/base64"
 	"github.com/picatz/jose/pkg/jwa"
 )
 
-// There are three classes of Header Parameter names: Registered Header
-// Parameter names, Public Header Parameter names, and Private Header
-// Parameter names.
+var (
+	// ErrParamaterNotFound is returned when a paramater is not found in the header.
+	ErrParamaterNotFound = errors.New("header: paramater not found")
+
+	// ErrInvalidParamaterType is returned when a paramater is not the expected type.
+	ErrInvalidParamaterType = errors.New("header: invalid paramater type")
+
+	// ErrFailedToEncodeHeader is returned when the header fails to be encoded.
+	ErrFailedToEncodeHeader = errors.New("header: failed to base64 URL encode")
+)
+
+// ParamaterName is one of three types: registered, public, or private.
 //
 // https://datatracker.ietf.org/doc/html/rfc7515#section-4
 type (
 	ParamaterName = string
 
+	// Registered header paramater names from the IANA registry.
+	//
+	// https://datatracker.ietf.org/doc/html/rfc7515#section-4.1
 	Registered = ParamaterName
-	Public     = ParamaterName
-	Private    = ParamaterName
+
+	// Public header paramater names that are not registered,
+	// but should be collision resistant.
+	//
+	// https://datatracker.ietf.org/doc/html/rfc7515#section-4.2
+	Public = ParamaterName
+
+	// Private header paramater names for use in private agreements.
+	//
+	// https://datatracker.ietf.org/doc/html/rfc7515#section-4.3
+	Private = ParamaterName
 )
 
 // Registered header paramater names used in JWS and JWE.
@@ -112,35 +134,42 @@ const (
 // Parameters is a JSON object containing the parameters describing
 // the cryptographic operations and parameters employed.
 //
-// The JOSE (JSON Object Signing and Encryption) Parameters is comprised
-// of a set of Parameters Parameters.
+// The JOSE (JSON Object Signing and Encryption) Header is comprised
+// of a set of Header Parameters.
+//
+// https://datatracker.ietf.org/doc/html/rfc7515#section-2
 type Parameters map[ParamaterName]any
 
+// Base64URLString returns the JOSE header as a base64 URL encoded string
+// suitable for use in a JWS or JWE.
 func (h Parameters) Base64URLString() (string, error) {
 	buff := bytes.NewBuffer(nil)
 	err := json.NewEncoder(buff).Encode(h)
 	if err != nil {
-		return "", fmt.Errorf("failed to encode JOSE header base64 URL string: %w", err)
+		return "", fmt.Errorf("%w: %w", ErrFailedToEncodeHeader, err)
 	}
 	return base64.Encode(buff.Bytes()), nil
 }
 
+// Type returns the media type of this complete JOSE object (JWS or JWE).
 func (h Parameters) Type() (string, error) {
 	value, ok := h[Type]
 	if !ok {
-		return "", fmt.Errorf("header does not contain a %q paramater", Type)
+		return "", fmt.Errorf("%w: %q", ErrParamaterNotFound, Type)
 	}
 	strValue, ok := value.(string)
 	if !ok {
-		return "", fmt.Errorf("header paramater %q is not a string, is %T", Type, value)
+		return "", fmt.Errorf("%w: %q: is type %T, not string", ErrInvalidParamaterType, Type, value)
 	}
 	return strValue, nil
 }
 
+// Algorithm returns the algorithm intended for use with the JWS or JWE;
+// the algorithm used to digitally sign the JWS or encrypt the JWE.
 func (h Parameters) Algorithm() (jwa.Algorithm, error) {
 	value, ok := h[Algorithm]
 	if !ok {
-		return "", fmt.Errorf("header does not contain a %q paramater", Algorithm)
+		return "", fmt.Errorf("%w: %q", ErrParamaterNotFound, Algorithm)
 	}
 
 	alg, ok := value.(jwa.Algorithm)
@@ -148,9 +177,12 @@ func (h Parameters) Algorithm() (jwa.Algorithm, error) {
 		return alg, nil
 	}
 
-	return "", fmt.Errorf("header paramater %q is invalid type %T", Algorithm, value)
+	return "", fmt.Errorf("%w: %q: is type %T, not algorithm", ErrInvalidParamaterType, Algorithm, value)
 }
 
+// SymetricAlgorithm returns the symetric algorithm used in the header,
+// if the algorithm is symetric. If the algorithm is not symetric, then
+// the function returns false.
 func (h Parameters) SymetricAlgorithm() (bool, error) {
 	alg, err := h.Algorithm()
 	if err != nil {
@@ -165,6 +197,9 @@ func (h Parameters) SymetricAlgorithm() (bool, error) {
 	return false, nil
 }
 
+// AsymetricAlgorithm returns the symetric algorithm used in the header,
+// if the algorithm is asymetric. If the algorithm is not asymetric, then
+// the function returns false.
 func (h Parameters) AsymetricAlgorithm() (bool, error) {
 	alg, err := h.Algorithm()
 	if err != nil {
@@ -185,10 +220,15 @@ func (h Parameters) AsymetricAlgorithm() (bool, error) {
 	return false, nil
 }
 
-func (h Parameters) Get(param ParamaterName) (interface{}, error) {
+// Get returns the value for a given paramater name from the set of JOSE header paramaters.
+//
+// This is a convenience function for accessing the value of a paramater from the JOSE header
+// without having to check if the paramater exists in the header first. This function will
+// return an error if the paramater does not exist in the header.
+func (h Parameters) Get(param ParamaterName) (any, error) {
 	value, ok := h[param]
 	if !ok {
-		return "", fmt.Errorf("header does not contain a %q paramater", Type)
+		return "", fmt.Errorf("%w: %q", ErrParamaterNotFound, param)
 	}
 	return value, nil
 }

--- a/pkg/header/header_test.go
+++ b/pkg/header/header_test.go
@@ -9,17 +9,111 @@ import (
 )
 
 func TestJSONDecode(t *testing.T) {
-	input := `{"typ":"JWT","alg":"HS256"}`
+	tests := []struct {
+		name  string
+		input string
+		check func(t *testing.T, params Parameters)
+	}{
+		{
+			name:  "typ and alg",
+			input: `{"typ":"JWT","alg":"HS256"}`,
+			check: func(t *testing.T, params Parameters) {
+				typ, err := params.Type()
+				require.NoError(t, err)
+				require.Equal(t, "JWT", typ)
 
-	params := Parameters{}
-	err := json.NewDecoder(strings.NewReader(input)).Decode(&params)
-	require.NoError(t, err)
+				alg, err := params.Algorithm()
+				require.NoError(t, err)
+				require.Equal(t, "HS256", alg)
+			},
+		},
+		{
+			name:  "typ and alg and kid",
+			input: `{"typ":"JWT","alg":"HS256","kid":"key-id"}`,
+			check: func(t *testing.T, params Parameters) {
+				typ, err := params.Type()
+				require.NoError(t, err)
+				require.Equal(t, "JWT", typ)
 
-	typ, err := params.Type()
-	require.NoError(t, err)
-	require.Equal(t, "JWT", typ)
+				alg, err := params.Algorithm()
+				require.NoError(t, err)
+				require.Equal(t, "HS256", alg)
 
-	b64urlStr, err := params.Base64URLString()
-	require.NoError(t, err)
-	require.NotEmpty(t, b64urlStr)
+				kid, err := params.Get(KeyID)
+				require.NoError(t, err)
+				require.Equal(t, "key-id", kid)
+			},
+		},
+		{
+			name:  "typ and alg and kid and crit",
+			input: `{"typ":"JWT","alg":"HS256","kid":"key-id","crit":["exp","nbf"]}`,
+			check: func(t *testing.T, params Parameters) {
+				typ, err := params.Type()
+				require.NoError(t, err)
+				require.Equal(t, "JWT", typ)
+
+				alg, err := params.Algorithm()
+				require.NoError(t, err)
+				require.Equal(t, "HS256", alg)
+
+				kid, err := params.Get(KeyID)
+				require.NoError(t, err)
+				require.Equal(t, "key-id", kid)
+
+				crit, err := params.Get(Critical)
+				require.NoError(t, err)
+				require.Equal(t, []any{"exp", "nbf"}, crit)
+			},
+		},
+		{
+			name:  "missing typ",
+			input: `{"alg":"HS256"}`,
+			check: func(t *testing.T, params Parameters) {
+				typ, err := params.Type()
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrParamaterNotFound)
+				require.Equal(t, "", typ)
+			},
+		},
+		{
+			name:  "missing alg",
+			input: `{"typ":"JWT"}`,
+			check: func(t *testing.T, params Parameters) {
+				alg, err := params.Algorithm()
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrParamaterNotFound)
+				require.Equal(t, "", alg)
+			},
+		},
+		{
+			name:  "invalid typ",
+			input: `{"typ":123,"alg":"HS256"}`,
+			check: func(t *testing.T, params Parameters) {
+				typ, err := params.Type()
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrInvalidParamaterType)
+				require.Equal(t, "", typ)
+			},
+		},
+		{
+			name:  "invalid alg",
+			input: `{"typ":"JWT","alg":123}`,
+			check: func(t *testing.T, params Parameters) {
+				alg, err := params.Algorithm()
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrInvalidParamaterType)
+				require.Equal(t, "", alg)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var params Parameters
+			err := json.NewDecoder(strings.NewReader(test.input)).Decode(&params)
+			require.NoError(t, err)
+
+			test.check(t, params)
+		})
+	}
 }

--- a/pkg/jwk/jwk.go
+++ b/pkg/jwk/jwk.go
@@ -26,25 +26,29 @@ type (
 )
 
 const (
-	KeyType              ParamaterName = "kty"
-	PublicKeyUse         ParamaterName = "use"
-	KeyOperations        ParamaterName = "key_ops"
-	Algorithm            ParamaterName = "alg"
-	KeyID                ParamaterName = "kid"
-	X509URL              ParamaterName = "x5u"
-	X509CertificateChain ParamaterName = "x5c"
-	X509SHA1Thumbprint   ParamaterName = "x5t"
-	X509SHA256Thumbprint ParamaterName = "x5t#S256"
+	KeyType              ParamaterName = "kty"      // https://datatracker.ietf.org/doc/html/rfc7517#section-4.1
+	PublicKeyUse         ParamaterName = "use"      // https://datatracker.ietf.org/doc/html/rfc7517#section-4.2
+	KeyOperations        ParamaterName = "key_ops"  // https://datatracker.ietf.org/doc/html/rfc7517#section-4.3
+	Algorithm            ParamaterName = "alg"      // https://datatracker.ietf.org/doc/html/rfc7517#section-4.4
+	KeyID                ParamaterName = "kid"      // https://datatracker.ietf.org/doc/html/rfc7517#section-4.5
+	X509URL              ParamaterName = "x5u"      // https://datatracker.ietf.org/doc/html/rfc7517#section-4.6
+	X509CertificateChain ParamaterName = "x5c"      // https://datatracker.ietf.org/doc/html/rfc7517#section-4.7
+	X509SHA1Thumbprint   ParamaterName = "x5t"      // https://datatracker.ietf.org/doc/html/rfc7517#section-4.8
+	X509SHA256Thumbprint ParamaterName = "x5t#S256" // https://datatracker.ietf.org/doc/html/rfc7517#section-4.9
 
+	// K is the symmetric key value within a JWK.
+	// https://datatracker.ietf.org/doc/html/rfc7517#appendix-A.3
 	K Symmetric = "k"
 
+	// Curve is the curve value within an ECDSA JWK, such as "P-256".
+	// https://datatracker.ietf.org/doc/html/rfc7517#appendix-A.3
 	Curve ECDSA = "crv"
-	X     ECDSA = "x"
-	Y     ECDSA = "y"
+	X     ECDSA = "x" // X is the x-coordinate for the elliptic curve point.
+	Y     ECDSA = "y" // Y is the y-coordinate for the elliptic curve point.
 
-	N RSA = "n"
-	E RSA = "e"
-	D RSA = "d"
+	N RSA = "n" // N is the RSA public modulus value.
+	E RSA = "e" // E is the RSA public exponent value.
+	D RSA = "d" // D is the RSA private exponent value.
 )
 
 // Values is a JSON object containing the parameters describing

--- a/pkg/jwt/jwt_test.go
+++ b/pkg/jwt/jwt_test.go
@@ -260,7 +260,11 @@ MC4CAQAwBQYDK2VwBCIEIFdZWoDdFny5SMnP9Fyfr8bafi/B527EVZh8JJjDTIFO
 	}()
 )
 
+// newToken returns a new token value with the given parameters, claims, and key.
+// If the key is not a supported type, an error is returned.
 func newToken(t *testing.T, params header.Parameters, claims ClaimsSet, key any) (*Token, error) {
+	t.Helper()
+
 	var (
 		token *Token
 		err   error

--- a/pkg/keyutil/keyutil.go
+++ b/pkg/keyutil/keyutil.go
@@ -160,6 +160,7 @@ func ParseECDSAPrivateKey(r io.Reader) (*ecdsa.PrivateKey, error) {
 	return privateKey, nil
 }
 
+// ParseEdDSAPublicKey parses the PEM encoded Ed25519 public key from the given reader.
 func ParseEdDSAPublicKey(r io.Reader) (ed25519.PublicKey, error) {
 	keyBytes, err := io.ReadAll(r)
 	if err != nil {
@@ -186,6 +187,7 @@ func ParseEdDSAPublicKey(r io.Reader) (ed25519.PublicKey, error) {
 	return ed25519.PublicKey(asn1PubKey.PublicKey.Bytes), nil
 }
 
+// ParseEdDSAPrivateKey parses the PEM encoded Ed25519 private key from the given reader.
 func ParseEdDSAPrivateKey(r io.Reader) (ed25519.PrivateKey, error) {
 	keyBytes, err := io.ReadAll(r)
 	if err != nil {
@@ -218,7 +220,8 @@ func ParseEdDSAPrivateKey(r io.Reader) (ed25519.PrivateKey, error) {
 	return ed25519.NewKeyFromSeed(seed), nil
 }
 
-func ParsePrivateKey(r io.Reader) (interface{}, error) {
+// ParsePrivateKey parses the PEM encoded private key from the given reader.
+func ParsePrivateKey(r io.Reader) (any, error) {
 	keyBytes, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read private key from reader: %w", err)
@@ -254,7 +257,8 @@ func ParsePrivateKey(r io.Reader) (interface{}, error) {
 	return nil, fmt.Errorf("failed to parse private key, unknown type")
 }
 
-func ParsePublicKey(r io.Reader) (interface{}, error) {
+// ParsePublicKey parses the PEM encoded public key from the given reader.
+func ParsePublicKey(r io.Reader) (any, error) {
 	keyBytes, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read private key from reader: %w", err)
@@ -296,6 +300,7 @@ func ParsePublicKey(r io.Reader) (interface{}, error) {
 	return nil, fmt.Errorf("failed to parse public key, unknown type")
 }
 
+// NewRSAKeyPair returns a new RSA key pair, or an error if one occurs.
 func NewRSAKeyPair() (*rsa.PublicKey, *rsa.PrivateKey, error) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -305,6 +310,7 @@ func NewRSAKeyPair() (*rsa.PublicKey, *rsa.PrivateKey, error) {
 	return &privateKey.PublicKey, privateKey, nil
 }
 
+// NewECDSAKeyPair returns a new ECDSA key pair, or an error if one occurs.
 func NewECDSAKeyPair() (*ecdsa.PublicKey, *ecdsa.PrivateKey, error) {
 	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
@@ -314,6 +320,7 @@ func NewECDSAKeyPair() (*ecdsa.PublicKey, *ecdsa.PrivateKey, error) {
 	return &privateKey.PublicKey, privateKey, nil
 }
 
+// NewEdDSAKeyPair returns a new EdDSA key pair, or an error if one occurs.
 func NewEdDSAKeyPair() (ed25519.PublicKey, ed25519.PrivateKey, error) {
 	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {

--- a/pkg/keyutil/keyutil.go
+++ b/pkg/keyutil/keyutil.go
@@ -44,7 +44,7 @@ func ParseRSAPublicKey(r io.Reader) (*rsa.PublicKey, error) {
 		return nil, fmt.Errorf("failed to decode RSA Public key PEM block: %w", err)
 	}
 
-	var parsedKey interface{}
+	var parsedKey any
 
 	parsedKey, err = x509.ParsePKIXPublicKey(block.Bytes)
 	if err != nil {
@@ -76,7 +76,7 @@ func ParseRSAPrivateKey(r io.Reader) (*rsa.PrivateKey, error) {
 		return nil, fmt.Errorf("failed to decode RSA private key PEM block: %w", err)
 	}
 
-	var parsedKey interface{}
+	var parsedKey any
 
 	parsedKey, err = x509.ParsePKCS1PrivateKey(block.Bytes)
 	if err != nil {
@@ -108,7 +108,7 @@ func ParseECDSAPublicKey(r io.Reader) (*ecdsa.PublicKey, error) {
 		return nil, fmt.Errorf("failed to decode ECDSA Public key PEM block: %w", err)
 	}
 
-	var parsedKey interface{}
+	var parsedKey any
 
 	parsedKey, err = x509.ParsePKIXPublicKey(block.Bytes)
 	if err != nil {
@@ -140,7 +140,7 @@ func ParseECDSAPrivateKey(r io.Reader) (*ecdsa.PrivateKey, error) {
 		return nil, fmt.Errorf("failed to decode ECDSA private key PEM block: %w", err)
 	}
 
-	var parsedKey interface{}
+	var parsedKey any
 
 	parsedKey, err = x509.ParseECPrivateKey(block.Bytes)
 	if err != nil {
@@ -229,7 +229,7 @@ func ParsePrivateKey(r io.Reader) (interface{}, error) {
 		return nil, fmt.Errorf("failed to decode private key PEM block: %w", err)
 	}
 
-	var parsedKey interface{}
+	var parsedKey any
 
 	parsedKey, err = x509.ParsePKCS1PrivateKey(block.Bytes)
 	if err == nil {
@@ -265,7 +265,7 @@ func ParsePublicKey(r io.Reader) (interface{}, error) {
 		return nil, fmt.Errorf("failed to decode private key PEM block: %w", err)
 	}
 
-	var parsedKey interface{}
+	var parsedKey any
 
 	parsedKey, err = x509.ParsePKIXPublicKey(block.Bytes)
 	if err == nil {


### PR DESCRIPTION
This PR does a little bit of cleanup to this project:
1. Attempting to improve or include additional comments.
2. When parsing JWTs, defer allocating `jwt.Token` object until header, claims, and signature parsed successfully. This avoids unnecessary allocations for a "sad" path when handling JWTs.
3. Start using `Err*`s for improved error handling for consumers of this package.
4. Some `go.mod` updates.
5. Prefer `any` to `interface{}`.
6. Other odds and ends.