### PR TITLE
Fix typos in headers and JWE docs

### DIFF
--- a/pkg/header/header.go
+++ b/pkg/header/header.go
@@ -152,9 +152,8 @@ func (h Parameters) Algorithm() (jwa.Algorithm, error) {
 	return Get[jwa.Algorithm](h, Algorithm)
 }
 
-// SymetricAlgorithm returns the symetric algorithm used in the header,
-// if the algorithm is symetric. If the algorithm is not symetric, then
-// the function returns false.
+// SymetricAlgorithm returns true if the algorithm used in the header is
+// symmetric. If the algorithm is not symmetric, the function returns false.
 func (h Parameters) SymetricAlgorithm() (bool, error) {
 	alg, err := h.Algorithm()
 	if err != nil {
@@ -169,9 +168,8 @@ func (h Parameters) SymetricAlgorithm() (bool, error) {
 	return false, nil
 }
 
-// AsymetricAlgorithm returns the symetric algorithm used in the header,
-// if the algorithm is asymetric. If the algorithm is not asymetric, then
-// the function returns false.
+// AsymetricAlgorithm returns true if the algorithm used in the header is
+// asymmetric. If the algorithm is not asymmetric, the function returns false.
 func (h Parameters) AsymetricAlgorithm() (bool, error) {
 	alg, err := h.Algorithm()
 	if err != nil {
@@ -190,11 +188,11 @@ func (h Parameters) AsymetricAlgorithm() (bool, error) {
 	return false, nil
 }
 
-// Get returns the value for a given paramater name from the set of JOSE header paramaters.
+// Get returns the value for a given parameter name from the set of JOSE header parameters.
 //
-// This is a convenience function for accessing the value of a paramater from the JOSE header
-// without having to check if the paramater exists in the header first. This function will
-// return an error if the paramater does not exist in the header.
+// This is a convenience function for accessing the value of a parameter from the JOSE header
+// without having to check if the parameter exists in the header first. This function will
+// return an error if the parameter does not exist in the header.
 func (h Parameters) Get(param ParameterName) (any, error) {
 	return Get[any](h, param)
 }

--- a/pkg/jwe/doc.go
+++ b/pkg/jwe/doc.go
@@ -1,3 +1,3 @@
-// Package jwe implements JSON Web Enryption (JWE) functionality as defined in
+// Package jwe implements JSON Web Encryption (JWE) functionality as defined in
 // RFC 7516.
 package jwe

--- a/pkg/jwe/jwe.go
+++ b/pkg/jwe/jwe.go
@@ -4,7 +4,7 @@ import (
 	"github.com/picatz/jose/pkg/header"
 )
 
-// Registered header paramater names used in JWE.
+// Registered header parameter names used in JWE.
 //
 // https://datatracker.ietf.org/doc/html/rfc7516#section-4.1
 const (


### PR DESCRIPTION
## Summary
- correct spelling errors in JWE docs
- clean up header documentation typos

## Testing
- `go test ./...` *(fails: Get "https://www.googleapis.com/oauth2/v3/certs": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6866c26fb77c8331b6c484f57375d50a