### PR TITLE
Fix typos and run JWK tests unconditionally

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,6 @@ if err != nil {
 
 [JOSE](https://datatracker.ietf.org/wg/jose/documents/) was developed by an IETF [working group](https://www.ietf.org/how/wgs/), 
  started in 2011. The group set out to develop a [JSON](https://datatracker.ietf.org/doc/html/rfc4627) syntax that could be 
-used by applications to describe "secure data objects". It has become a well known, standardized mechanism for integrity protection 
+used by applications to describe "secure data objects". It has become a well-known, standardized mechanism for integrity protection 
 and encryption, as well as the format for keys and algorithm identifiers to support interoperability of security services for 
 protocols that use JSON.

--- a/pkg/header/header.go
+++ b/pkg/header/header.go
@@ -188,11 +188,11 @@ func (h Parameters) AsymmetricAlgorithm() (bool, error) {
 	return false, nil
 }
 
-// Get returns the value for a given paramater name from the set of JOSE header paramaters.
+// Get returns the value for a given parameter name from the set of JOSE header parameters.
 //
-// This is a convenience function for accessing the value of a paramater from the JOSE header
-// without having to check if the paramater exists in the header first. This function will
-// return an error if the paramater does not exist in the header.
+// This is a convenience function for accessing the value of a parameter from the JOSE header
+// without having to check if the parameter exists in the header first. This function will
+// return an error if the parameter does not exist in the header.
 func (h Parameters) Get(param ParameterName) (any, error) {
 	return Get[any](h, param)
 }

--- a/pkg/jwe/doc.go
+++ b/pkg/jwe/doc.go
@@ -1,3 +1,3 @@
-// Package jwe implements JSON Web Enryption (JWE) functionality as defined in
+// Package jwe implements JSON Web Encryption (JWE) functionality as defined in
 // RFC 7516.
 package jwe

--- a/pkg/jwe/jwe.go
+++ b/pkg/jwe/jwe.go
@@ -4,7 +4,7 @@ import (
 	"github.com/picatz/jose/pkg/header"
 )
 
-// Registered header paramater names used in JWE.
+// Registered header parameter names used in JWE.
 //
 // https://datatracker.ietf.org/doc/html/rfc7516#section-4.1
 const (

--- a/pkg/jwk/jwk_test.go
+++ b/pkg/jwk/jwk_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/elliptic"
 	"encoding/json"
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -22,14 +21,6 @@ func createTestHTTPContext(t *testing.T, timeout time.Duration) (context.Context
 	}
 	t.Cleanup(cancel)
 	return ctx, client
-}
-
-// skipIfExternalJWKTestsDisabled skips tests that fetch external JWKs when the
-// RUN_EXTERNAL_JWK_TESTS environment variable is not set.
-func skipIfExternalJWKTestsDisabled(t *testing.T) {
-	if os.Getenv("RUN_EXTERNAL_JWK_TESTS") == "" {
-		t.Skip("skipping external JWK tests; set RUN_EXTERNAL_JWK_TESTS=1 to run")
-	}
 }
 
 func TestValueECDSA(t *testing.T) {
@@ -159,7 +150,6 @@ func TestSet(t *testing.T) {
 }
 
 func TestGoogleWellKnownCertsV3(t *testing.T) {
-	skipIfExternalJWKTestsDisabled(t)
 	ctx, httpClient := createTestHTTPContext(t, 5*time.Second)
 
 	// https://accounts.google.com/.well-known/openid-configuration
@@ -197,7 +187,6 @@ func TestGoogleWellKnownCertsV3(t *testing.T) {
 }
 
 func TestMicrosoftLoginWellKnownKeys(t *testing.T) {
-	skipIfExternalJWKTestsDisabled(t)
 	ctx, httpClient := createTestHTTPContext(t, 5*time.Second)
 
 	// https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration

--- a/pkg/jwt/claims.go
+++ b/pkg/jwt/claims.go
@@ -87,11 +87,11 @@ func (claims ClaimsSet) Names() []ClaimName {
 	return names
 }
 
-// GetCalimValue returns the ClaimValue for the given ClaimName of type T.
+// GetClaimValue returns the ClaimValue for the given ClaimName of type T.
 //
 // It returns an error if the ClaimValue is not of type T, or if the ClaimName
 // is not found in the ClaimsSet.
-func GetCalimValue[T any](claims ClaimsSet, name ClaimName) (T, error) {
+func GetClaimValue[T any](claims ClaimsSet, name ClaimName) (T, error) {
 	var empty T
 
 	value, err := claims.Get(name)

--- a/pkg/jwt/jwt.go
+++ b/pkg/jwt/jwt.go
@@ -579,7 +579,7 @@ func WithAllowedAlgorithms(algs ...jwa.Algorithm) VerifyOption {
 // randomly generated key ID.
 //
 // This is the preferred way to add a key to the set of allowed keys,
-// because it will ensure that the givne key is of the correct type
+// because it will ensure that the given key is of the correct type
 // at compile time.
 func WithKey[T jwa.VerifyKey](key T) VerifyOption {
 	return func(vc *VerifyConfig) error {
@@ -607,7 +607,7 @@ func WithKey[T jwa.VerifyKey](key T) VerifyOption {
 // WithIdentifiableKey adds a key by ID to the set of allowed keys for the JWT.
 //
 // This is the preferred way to add a key to the set of allowed keys,
-// because it will ensure that the givne key is of the correct type
+// because it will ensure that the given key is of the correct type
 // at compile time.
 func WithIdentifiableKey[T jwa.VerifyKey](kid string, key T) VerifyOption {
 	return func(vc *VerifyConfig) error {

--- a/pkg/keyutil/keyutil.go
+++ b/pkg/keyutil/keyutil.go
@@ -26,7 +26,7 @@ func NewSymmetricKey(size int) ([]byte, error) {
 
 	_, err := rand.Read(key)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate new symmetic key: %w", err)
+		return nil, fmt.Errorf("failed to generate new symmetric key: %w", err)
 	}
 
 	return key, nil
@@ -181,7 +181,7 @@ func ParseEdDSAPublicKey(r io.Reader) (ed25519.PublicKey, error) {
 
 	_, err = asn1.Unmarshal(block.Bytes, &asn1PubKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse EdDSA public key ANS.1")
+		return nil, fmt.Errorf("failed to parse EdDSA public key ASN.1")
 	}
 
 	return ed25519.PublicKey(asn1PubKey.PublicKey.Bytes), nil
@@ -209,7 +209,7 @@ func ParseEdDSAPrivateKey(r io.Reader) (ed25519.PrivateKey, error) {
 
 	_, err = asn1.Unmarshal(block.Bytes, &asn1PrivKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse EdDSA private key ANS.1")
+		return nil, fmt.Errorf("failed to parse EdDSA private key ASN.1")
 	}
 
 	seed := asn1PrivKey.PrivateKey[2:]


### PR DESCRIPTION
## Summary
- correct header parameter documentation wording
- fix JWE package description typo
- drop environment variable skip logic from JWK tests
- fix claims helper name typo
- update README history text
- tweak keyutil error messages

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6866c7cf9674833186a30e7881f88472